### PR TITLE
fix: updated biling date

### DIFF
--- a/src/pages/Payment/PaymentInformation/ChangePlanPage.svelte
+++ b/src/pages/Payment/PaymentInformation/ChangePlanPage.svelte
@@ -392,34 +392,6 @@
     captureEvent('admin_plan_upgraded', eventProperties);
   };
   
-  function getExpiryDate(createdAt: string): string {
-    if (!createdAt) return '-';
-    const created = new Date(createdAt);
-    const expiry = new Date(created);
-    expiry.setDate(expiry.getDate() + 30);
-
-    // Format like "28 Aug 2025, 10:00 AM UTC"
-    const options: Intl.DateTimeFormatOptions = {
-      day: '2-digit',
-      month: 'short',
-      year: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: true,
-      timeZone: 'UTC',
-    };
-
-    // Calculate days left
-    const now = new Date();
-    const diffInMs = expiry.getTime() - now.getTime();
-    const daysLeft = Math.max(Math.ceil(diffInMs / (1000 * 60 * 60 * 24)), 0); // avoid negative
-
-    const formattedExpiry = expiry.toLocaleString('en-GB', options) + ' UTC';
-    return `${formattedExpiry} (${daysLeft} day${daysLeft !== 1 ? 's' : ''} left)`;
-  }
-
-  $: expiryDate = getExpiryDate(createdAt);
-  
   function removeAdminFromMembersList(hubOwner, members = []) {
     if (!hubOwner) return members;
     return members.filter((member) => member.id !== hubOwner);
@@ -885,7 +857,7 @@
       fromPlan={currentPlan}
       toPlan={selectedPlan}
       PlanUpdateTitle="Your Downgrade is Scheduled"
-      description={`You've successfully scheduled the ${hubName} to downgrade to the ${selectedPlan} edition. This change will take effect on ${expiryDate}.
+      description={`You've successfully scheduled the ${hubName} to downgrade to the ${selectedPlan} edition. This change will take effect on ${nextBillingDate}.
         You can upgrade anytime and continue with the features.`}
       buttonText="Got it"
       on:close={() => {


### PR DESCRIPTION
## PR Agent Description

### PR Type

Bug fix, Enhancement

### Description

- Remove local `getExpiryDate` function that hardcoded a 30-day expiry from `createdAt`
- Use `nextBillingDate` from URL query params for accurate billing-cycle-aligned dates
- Update all modal props and success message to reference `nextBillingDate`

### Changes Diagram

```mermaid
flowchart LR
  A["URL query params"] --> B["nextBillingDate parsed"]
  B --> C["Downgrade success message"]
  B --> D["DowngradePlanModal prop"]
  B --> E["ReviewScheduledDowngradeModal prop"]
  F["Removed getExpiryDate()"] --> G["No more 30-day hardcoded expiry"]
```

### File Walkthrough

<details>
<summary>Enhancement (1 file)</summary>

<details>
<summary>Replace computed expiry with server-provided date</summary>

<a href="https://github.com/sparrowapp-dev/sparrow-admin-app/pull/316/files#diff-39a7796a83b4ba8e48d38f7a92b4bf36407857d902286c400a7397227c8c6a4e"><code>src/pages/Payment/PaymentInformation/ChangePlanPage.svelte</code></a>

- Removed `getExpiryDate()` function and its reactive `$: expiryDate` binding
- Added `nextBillingDate` to URL search param parsing
- Updated all modal props and success description to use `nextBillingDate`

</details>

</details>